### PR TITLE
Added handling missing Link or Id

### DIFF
--- a/FeedCord/src/Services/Helpers/PostBuilder.cs
+++ b/FeedCord/src/Services/Helpers/PostBuilder.cs
@@ -68,11 +68,11 @@ namespace FeedCord.Services.Helpers
             int trim,
             string imageUrl)
         {
-            if (feed.Link.Contains("reddit.com"))
+            if (feed.Link?.Contains("reddit.com") == true)
             {
                 return TryBuildRedditPost(post, feed, trim, imageUrl);
             }
-            else if (post.Id.Contains("gitlab.com"))
+            else if (post.Id?.Contains("gitlab.com") == true)
             {
                 return TryBuildGitlabPost(post, feed, trim, imageUrl);
             }


### PR DESCRIPTION
Added checks to handle a missing link or id, and not error out with:

```
An unexpected error occurred while parsing the RSS feed: System.NullReferenceException: Object reference not set to an instance of an object.
at FeedCord.Services.Helpers.PostBuilder.TryBuildPost(FeedItem post, Feed feed, Int32 trim, String imageUrl) in /src/src/Services/Helpers/PostBuilder.cs:line 71
at FeedCord.Services.RssParsingService.ParseRssFeedAsync(String xmlContent, Int32 trim) in /src/src/Services/RssParsingService.cs:line 50
```